### PR TITLE
Fix doc tests: replace rsa:: with sad_rsa:: imports

### DIFF
--- a/benches/key.rs
+++ b/benches/key.rs
@@ -7,7 +7,7 @@ use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use rand::rngs::ChaCha8Rng;
 use rand_core::SeedableRng;
-use rsa::{Pkcs1v15Encrypt, Pkcs1v15Sign, RsaPrivateKey};
+use sad_rsa::{Pkcs1v15Encrypt, Pkcs1v15Sign, RsaPrivateKey};
 use sha2::{Digest, Sha256};
 use test::Bencher;
 

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -9,7 +9,7 @@
 use alloc::vec::Vec;
 use const_oid::AssociatedOid;
 use crypto_bigint::{BoxedUint, Choice, CtEq, CtSelect};
-use digest::{Digest, Mac, KeyInit};
+use digest::{Digest, KeyInit, Mac};
 use hmac::Hmac;
 use rand_core::TryCryptoRng;
 use sha2::Sha256;
@@ -210,8 +210,7 @@ pub(crate) fn pkcs1v15_encrypt_unpad(em: Vec<u8>, k: usize, kdk: &[u8; 32]) -> V
 
     // Constant-time selection of length
     let valid_choice = Choice::from_u8_lsb(valid);
-    let output_length =
-        usize::ct_select(&synthetic_length, &actual_length, valid_choice);
+    let output_length = usize::ct_select(&synthetic_length, &actual_length, valid_choice);
 
     // Constant-time selection of message
     // This ensures both actual and synthetic messages are accessed

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -65,7 +65,7 @@ where
     /// ```
     /// use sha1::Sha1;
     /// use sha2::Sha256;
-    /// use rsa::{RsaPublicKey, Oaep};
+    /// use sad_rsa::{RsaPublicKey, Oaep};
     /// use base64ct::{Base64, Encoding};
     /// use crypto_bigint::BoxedUint;
     ///
@@ -74,7 +74,7 @@ where
     /// let n = BoxedUint::from_be_slice(&n_bytes, 2048).unwrap();
     /// let e = BoxedUint::from_be_slice(&e_bytes, 32).unwrap();
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::rng();
     /// let key = RsaPublicKey::new(n, e).unwrap();
     /// let padding = Oaep::<Sha256>::new();
     /// let encrypted_data = key.encrypt(&mut rng, padding, b"secret").unwrap();
@@ -109,7 +109,7 @@ where
     /// ```
     /// use sha1::Sha1;
     /// use sha2::Sha256;
-    /// use rsa::{RsaPublicKey, Oaep};
+    /// use sad_rsa::{RsaPublicKey, Oaep};
     /// use base64ct::{Base64, Encoding};
     /// use crypto_bigint::BoxedUint;
     ///
@@ -118,7 +118,7 @@ where
     /// let n = BoxedUint::from_be_slice(&n_bytes, 2048).unwrap();
     /// let e = BoxedUint::from_be_slice(&e_bytes, 32).unwrap();
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::rng();
     /// let key = RsaPublicKey::new(n, e).unwrap();
     /// let padding = Oaep::<Sha256, Sha1>::new_with_mgf_hash();
     /// let encrypted_data = key.encrypt(&mut rng, padding, b"secret").unwrap();

--- a/tests/marvin_attack.rs
+++ b/tests/marvin_attack.rs
@@ -57,10 +57,13 @@ fn test_valid_ciphertext_decrypts_correctly() {
         let ciphertext = RandomizedEncryptor::encrypt_with_rng(&encrypting_key, &mut rng, &message)
             .expect("encryption should succeed");
 
-        let decrypted = Decryptor::decrypt(&decrypting_key, &ciphertext)
-            .expect("decryption should succeed");
+        let decrypted =
+            Decryptor::decrypt(&decrypting_key, &ciphertext).expect("decryption should succeed");
 
-        assert_eq!(message, decrypted, "Valid ciphertext should decrypt to original message");
+        assert_eq!(
+            message, decrypted,
+            "Valid ciphertext should decrypt to original message"
+        );
     }
 }
 
@@ -74,10 +77,19 @@ fn test_invalid_ciphertext_returns_synthetic_message() {
 
     let result = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext);
 
-    assert!(result.is_ok(), "Invalid ciphertext should return synthetic message, not error");
+    assert!(
+        result.is_ok(),
+        "Invalid ciphertext should return synthetic message, not error"
+    );
     let synthetic_message = result.unwrap();
-    assert!(!synthetic_message.is_empty(), "Synthetic message should not be empty");
-    assert!(synthetic_message.len() <= k - 11, "Synthetic message length should be <= k-11");
+    assert!(
+        !synthetic_message.is_empty(),
+        "Synthetic message should not be empty"
+    );
+    assert!(
+        synthetic_message.len() <= k - 11,
+        "Synthetic message length should be <= k-11"
+    );
 }
 
 #[test]
@@ -89,12 +101,21 @@ fn test_deterministic_synthetic_messages() {
     let mut invalid_ciphertext = vec![0u8; k];
     invalid_ciphertext[0] = 0x01; // Small value < n
 
-    let result1 = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext).expect("should return synthetic message");
-    let result2 = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext).expect("should return synthetic message");
-    let result3 = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext).expect("should return synthetic message");
+    let result1 = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext)
+        .expect("should return synthetic message");
+    let result2 = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext)
+        .expect("should return synthetic message");
+    let result3 = Decryptor::decrypt(&decrypting_key, &invalid_ciphertext)
+        .expect("should return synthetic message");
 
-    assert_eq!(result1, result2, "Same invalid ciphertext should produce same synthetic message");
-    assert_eq!(result2, result3, "Synthetic message should be deterministic");
+    assert_eq!(
+        result1, result2,
+        "Same invalid ciphertext should produce same synthetic message"
+    );
+    assert_eq!(
+        result2, result3,
+        "Synthetic message should be deterministic"
+    );
 }
 
 #[test]
@@ -109,10 +130,15 @@ fn test_different_invalid_ciphertexts_produce_different_synthetic_messages() {
     let mut invalid_ct2 = vec![0u8; k];
     invalid_ct2[0] = 0x02;
 
-    let synthetic1 = Decryptor::decrypt(&decrypting_key, &invalid_ct1).expect("should return synthetic message");
-    let synthetic2 = Decryptor::decrypt(&decrypting_key, &invalid_ct2).expect("should return synthetic message");
+    let synthetic1 =
+        Decryptor::decrypt(&decrypting_key, &invalid_ct1).expect("should return synthetic message");
+    let synthetic2 =
+        Decryptor::decrypt(&decrypting_key, &invalid_ct2).expect("should return synthetic message");
 
-    assert_ne!(synthetic1, synthetic2, "Different invalid ciphertexts should produce different synthetic messages");
+    assert_ne!(
+        synthetic1, synthetic2,
+        "Different invalid ciphertexts should produce different synthetic messages"
+    );
 }
 
 #[test]
@@ -131,7 +157,10 @@ fn test_invalid_padding_corruption() {
     corrupted[k - 5] ^= 0xFF;
 
     let result = Decryptor::decrypt(&decrypting_key, &corrupted);
-    assert!(result.is_ok(), "Corrupted ciphertext should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Corrupted ciphertext should return synthetic message"
+    );
 }
 
 #[test]
@@ -151,10 +180,17 @@ fn test_short_padding_string() {
     em[10] = 0xAA;
 
     let result = Decryptor::decrypt(&decrypting_key, &em);
-    assert!(result.is_ok(), "Short padding should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Short padding should return synthetic message"
+    );
 
     let result2 = Decryptor::decrypt(&decrypting_key, &em);
-    assert_eq!(result.unwrap(), result2.unwrap(), "Deterministic synthetic message");
+    assert_eq!(
+        result.unwrap(),
+        result2.unwrap(),
+        "Deterministic synthetic message"
+    );
 }
 
 #[test]
@@ -173,7 +209,10 @@ fn test_wrong_first_byte() {
     em[12] = 0xAA;
 
     let result = Decryptor::decrypt(&decrypting_key, &em);
-    assert!(result.is_ok(), "Wrong first byte should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Wrong first byte should return synthetic message"
+    );
 }
 
 #[test]
@@ -192,7 +231,10 @@ fn test_wrong_second_byte() {
     em[12] = 0xAA;
 
     let result = Decryptor::decrypt(&decrypting_key, &em);
-    assert!(result.is_ok(), "Wrong second byte should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Wrong second byte should return synthetic message"
+    );
 }
 
 #[test]
@@ -212,7 +254,10 @@ fn test_zero_in_padding_string() {
     em[12] = 0xAA;
 
     let result = Decryptor::decrypt(&decrypting_key, &em);
-    assert!(result.is_ok(), "Zero in padding string should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Zero in padding string should return synthetic message"
+    );
 }
 
 #[test]
@@ -229,7 +274,10 @@ fn test_no_separator_byte() {
     }
 
     let result = Decryptor::decrypt(&decrypting_key, &em);
-    assert!(result.is_ok(), "Missing separator should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Missing separator should return synthetic message"
+    );
 }
 
 #[test]
@@ -251,7 +299,10 @@ fn test_synthetic_message_unpredictability() {
 
     for i in 0..synthetic_messages.len() {
         for j in i + 1..synthetic_messages.len() {
-            assert_ne!(synthetic_messages[i], synthetic_messages[j], "Synthetic messages should all be different");
+            assert_ne!(
+                synthetic_messages[i], synthetic_messages[j],
+                "Synthetic messages should all be different"
+            );
         }
     }
 }
@@ -270,14 +321,26 @@ fn test_valid_and_invalid_mixed() {
 
     let invalid_ct = vec![0x01; k]; // Small values < n
 
-    let valid_result = Decryptor::decrypt(&decrypting_key, &valid_ct).expect("valid ciphertext should decrypt");
-    assert_eq!(valid_result, message, "Valid message should decrypt correctly");
+    let valid_result =
+        Decryptor::decrypt(&decrypting_key, &valid_ct).expect("valid ciphertext should decrypt");
+    assert_eq!(
+        valid_result, message,
+        "Valid message should decrypt correctly"
+    );
 
-    let invalid_result = Decryptor::decrypt(&decrypting_key, &invalid_ct).expect("invalid ciphertext should return synthetic message");
-    assert_ne!(invalid_result, message, "Invalid ciphertext should not decrypt to original message");
+    let invalid_result = Decryptor::decrypt(&decrypting_key, &invalid_ct)
+        .expect("invalid ciphertext should return synthetic message");
+    assert_ne!(
+        invalid_result, message,
+        "Invalid ciphertext should not decrypt to original message"
+    );
 
-    let valid_result2 = Decryptor::decrypt(&decrypting_key, &valid_ct).expect("valid ciphertext should still decrypt");
-    assert_eq!(valid_result2, message, "Valid message should still decrypt correctly");
+    let valid_result2 = Decryptor::decrypt(&decrypting_key, &valid_ct)
+        .expect("valid ciphertext should still decrypt");
+    assert_eq!(
+        valid_result2, message,
+        "Valid message should still decrypt correctly"
+    );
 }
 
 #[test]
@@ -296,7 +359,10 @@ fn test_ciphertext_length_variations() {
 
     let exact_ct = vec![0x01; k]; // Valid length, < n, but invalid padding
     let result = Decryptor::decrypt(&decrypting_key, &exact_ct);
-    assert!(result.is_ok(), "Exact size invalid ciphertext should return synthetic message");
+    assert!(
+        result.is_ok(),
+        "Exact size invalid ciphertext should return synthetic message"
+    );
 }
 
 #[test]
@@ -311,10 +377,15 @@ fn test_kdk_derivation_varies_with_ciphertext() {
     let mut ct2 = vec![0x01; k];
     ct2[k - 1] = 0x20;
 
-    let synthetic1 = Decryptor::decrypt(&decrypting_key, &ct1).expect("should return synthetic message");
-    let synthetic2 = Decryptor::decrypt(&decrypting_key, &ct2).expect("should return synthetic message");
+    let synthetic1 =
+        Decryptor::decrypt(&decrypting_key, &ct1).expect("should return synthetic message");
+    let synthetic2 =
+        Decryptor::decrypt(&decrypting_key, &ct2).expect("should return synthetic message");
 
-    assert_ne!(synthetic1, synthetic2, "Different ciphertexts should produce different synthetic messages");
+    assert_ne!(
+        synthetic1, synthetic2,
+        "Different ciphertexts should produce different synthetic messages"
+    );
 }
 
 #[test]
@@ -335,7 +406,12 @@ fn test_synthetic_message_length_variations() {
     }
 
     for &len in &lengths {
-        assert!(len <= k - 11, "Synthetic message length {} should be <= {}", len, k - 11);
+        assert!(
+            len <= k - 11,
+            "Synthetic message length {} should be <= {}",
+            len,
+            k - 11
+        );
     }
 }
 
@@ -353,7 +429,11 @@ fn test_implicit_rejection_with_blinding() {
     let decrypted = RandomizedDecryptor::decrypt_with_rng(&decrypting_key, &mut rng, &valid_ct)
         .expect("decryption with blinding should succeed");
 
-    assert_eq!(message, decrypted.as_slice(), "Blinded decryption should work correctly");
+    assert_eq!(
+        message,
+        decrypted.as_slice(),
+        "Blinded decryption should work correctly"
+    );
 
     let k = 64;
     let invalid_ct = vec![0x01; k]; // Small values < n
@@ -363,5 +443,8 @@ fn test_implicit_rejection_with_blinding() {
     let synthetic2 = RandomizedDecryptor::decrypt_with_rng(&decrypting_key, &mut rng, &invalid_ct)
         .expect("should be deterministic");
 
-    assert_eq!(synthetic, synthetic2, "Synthetic message should be deterministic even with blinding");
+    assert_eq!(
+        synthetic, synthetic2,
+        "Synthetic message should be deterministic even with blinding"
+    );
 }

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -4,14 +4,14 @@
 
 use crypto_bigint::{BoxedUint, CtEq};
 use hex_literal::hex;
-use rsa::{
+use sad_rsa::{
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
     traits::{PrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
 
 #[cfg(feature = "encoding")]
-use rsa::pkcs1::LineEnding;
+use sad_rsa::pkcs1::LineEnding;
 
 /// RSA-2048 PKCS#1 private key encoded as ASN.1 DER.
 ///

--- a/tests/pkcs1v15.rs
+++ b/tests/pkcs1v15.rs
@@ -5,8 +5,8 @@ fn signature_stringify() {
     use pkcs8::DecodePrivateKey;
     use signature::Signer;
 
-    use rsa::pkcs1v15::SigningKey;
-    use rsa::RsaPrivateKey;
+    use sad_rsa::pkcs1v15::SigningKey;
+    use sad_rsa::RsaPrivateKey;
 
     let pem = include_str!("examples/pkcs8/rsa2048-priv.pem");
     let private_key = RsaPrivateKey::from_pkcs8_pem(pem).unwrap();
@@ -26,7 +26,7 @@ fn signature_stringify() {
 #[test]
 fn signing_key_new_same_as_from() {
     use pkcs1::DecodeRsaPrivateKey;
-    use rsa::RsaPrivateKey;
+    use sad_rsa::RsaPrivateKey;
     use signature::{Keypair, Signer, Verifier};
 
     // randomly generated key, hardcoded for test repeatability
@@ -62,8 +62,8 @@ Rmb665iB5fwpqmbE/hYKIn7asYQE+V0dkgt8M3qvlJJ5JJbCrJx3
 
     let msg = b"1234";
 
-    let key_via_new = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(priv_key.clone());
-    let key_via_from = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::from(priv_key.clone());
+    let key_via_new = sad_rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(priv_key.clone());
+    let key_via_from = sad_rsa::pkcs1v15::SigningKey::<sha2::Sha256>::from(priv_key.clone());
     let sig_via_new = key_via_new.sign(msg);
     let sig_via_from = key_via_from.sign(msg);
     assert_eq!(sig_via_new, sig_via_from);

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -4,7 +4,7 @@
 
 use crypto_bigint::{BoxedUint, CtEq};
 use hex_literal::hex;
-use rsa::{
+use sad_rsa::{
     pkcs1v15,
     pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey},
     pss,
@@ -14,7 +14,7 @@ use rsa::{
 use sha2::Sha256;
 
 #[cfg(feature = "encoding")]
-use rsa::pkcs8::LineEnding;
+use sad_rsa::pkcs8::LineEnding;
 
 /// RSA-2048 PKCS#8 private key encoded as ASN.1 DER
 const RSA_2048_PRIV_DER: &[u8] = include_bytes!("examples/pkcs8/rsa2048-priv.der");

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -5,7 +5,7 @@
 use proptest::prelude::*;
 use rand::rngs::ChaCha8Rng;
 use rand_core::SeedableRng;
-use rsa::{
+use sad_rsa::{
     pkcs1v15,
     signature::{Keypair, SignatureEncoding, Signer, Verifier},
     RsaPrivateKey,

--- a/tests/wycheproof.rs
+++ b/tests/wycheproof.rs
@@ -8,12 +8,12 @@
 use std::fs::File;
 
 use pkcs1::DecodeRsaPublicKey;
-use rsa::{
+use rstest::rstest;
+use sad_rsa::{
     pkcs1v15, pss,
     signature::{Error as SignatureError, Verifier},
     RsaPublicKey,
 };
-use rstest::rstest;
 use serde::Deserialize;
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
@@ -218,7 +218,7 @@ fn test_rsa_pss_verify(#[case] file: &str) {
     for group in tests.groups {
         summary.group(&group);
 
-        let key = rsa::RsaPublicKey::from_pkcs1_der(&group.public_key_asn).unwrap();
+        let key = sad_rsa::RsaPublicKey::from_pkcs1_der(&group.public_key_asn).unwrap();
         println!("key is {:?}", key);
 
         for test in group.tests {


### PR DESCRIPTION
## Summary
- Fixed doc tests in `src/oaep.rs` that were using `use rsa::` instead of `use sad_rsa::`
- Fixed deprecated `rand::thread_rng()` to `rand::rng()`
- Updated all test files (`tests/*.rs`) to use `sad_rsa::` imports

## Test plan
- [x] `cargo test --doc --no-default-features` passes
- [x] `cargo test --release --lib` passes (69 tests)
- [x] `cargo test --release --doc` passes (6 tests, 3 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)