### PR TITLE
chore: Release v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sad-rsa"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sadco Security Team", "RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Hardened pure Rust RSA implementation with Marvin attack mitigation"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.1 for crates.io release

## Changes in v0.1.1
- Fixed crypto-primes RngCore trait bound issue (cross-platform compilation fix)
- Fixed SysRng import (moved from crypto_common to getrandom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)